### PR TITLE
separated sides from entrees, also fixed mealtype image to initial pl…

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,43 +39,56 @@
                         Plate</button>
                 </div>
             </div>
-            <div id="option-1">
+            <div id="side">
                 <div class="mini-header">
                     <img id="mini-logo" src="source/imgs/panda.png" alt="Panda Express Logo">
-                    <h2>Choose your first option!</h2>
+                    <h2>Choose your side!</h2>
                 </div>
-                <div class="center"><img id="current-item" src="source/imgs/bowl.png"></div>
+                <div class="center"><img class="current-item" src="source/imgs/bowl.png"></div>
                 <div id="plate-button-container">
-                    <button id="option-1-1"><img src="">Broccoli</button>
+                    <button id="option-1-1"><img src="">Chow Mein</button>
                     <button id="option-1-2"><img src="source/imgs/rice.png">White Rice</button>
                     <button id="option-1-3"><img src="">Fried Rice</button>
                     <button id="option-1-4"><img src="">Random Option</button>
                 </div>
             </div>
-            <div id="option-2">
+            <div id="entree-1">
                 <div class="mini-header">
                     <img id="mini-logo" src="source/imgs/panda.png" alt="Panda Express Logo">
-                    <h2>Choose your second option!</h2>
+                    <h2>Choose your first entree!</h2>
                 </div>
-                <div class="center"><img id="current-item" src="source/imgs/plate.png"></div>
+                <div class="center"><img class="current-item" src="source/imgs/bowl.png"></div>
                 <div id="plate-button-container">
                     <button id="option-2-1"><img src="">Broccoli Beef</button>
-                    <button id="option-2-2"><img src="source/imgs/shrimp.png">Sizzling Shrimp</button>
-                    <button id="option-2-3"><img src="source/imgs/beef.png">Benijing Beef</button>
+                    <button id="option-2-2"><img src="">White Rice</button>
+                    <button id="option-2-3"><img src="">Fried Rice</button>
                     <button id="option-2-4"><img src="">Random Option</button>
                 </div>
             </div>
-            <div id="option-3">
+            <div id="entree-2">
                 <div class="mini-header">
                     <img id="mini-logo" src="source/imgs/panda.png" alt="Panda Express Logo">
-                    <h2>Choose your third option!</h2>
+                    <h2>Choose your second entree!</h2>
                 </div>
-                <div class="center"><img id="current-item" src="source/imgs/large plate.png"></div>
+                <div class="center"><img class="current-item" src="source/imgs/plate.png"></div>
                 <div id="plate-button-container">
-                    <button id="option-3-1"><img src="source/imgs/beef.png">String Bean Chicken</button>
-                    <button id="option-3-2"><img src="source/imgs/chicken.png">Honey Walnut Shrimp</button>
-                    <button id="option-3-3"><img src="source/imgs/noodles.png">Kung Pao Chicken</button>
-                    <button id="option-3-4"><img src="source/imgs/rice.png">Random Option</button>
+                    <button id="option-3-1"><img src="">Broccoli Beef</button>
+                    <button id="option-3-2"><img src="source/imgs/shrimp.png">Sizzling Shrimp</button>
+                    <button id="option-3-3"><img src="source/imgs/beef.png">Benijing Beef</button>
+                    <button id="option-3-4"><img src="">Random Option</button>
+                </div>
+            </div>
+            <div id="entree-3">
+                <div class="mini-header">
+                    <img id="mini-logo" src="source/imgs/panda.png" alt="Panda Express Logo">
+                    <h2>Choose your third entree!</h2>
+                </div>
+                <div class="center"><img class="current-item" src="source/imgs/large plate.png"></div>
+                <div id="plate-button-container">
+                    <button id="option-4-1"><img src="source/imgs/beef.png">String Bean Chicken</button>
+                    <button id="option-4-2"><img src="source/imgs/chicken.png">Honey Walnut Shrimp</button>
+                    <button id="option-4-3"><img src="">Kung Pao Chicken</button>
+                    <button id="option-4-4"><img src="">Random Option</button>
                 </div>
             </div>
             <div id="fortune-cookie-reveal">
@@ -83,7 +96,7 @@
                     <img id="mini-logo" src="source/imgs/panda.png" alt="Panda Express Logo">
                     <h2>Open your Fortune Cookie! Will you be lucky?</h2>
                 </div>
-                <div class="center"><img id="current-item" src="source/imgs/closed fortune cookie.png"></div>
+                <div class="center"><img class="cookie-display" src="source/imgs/closed fortune cookie.png"></div>
                 <div id="plate-button-container">
                     <button id="open">Open</button>
                 </div>
@@ -93,7 +106,7 @@
                     <img id="mini-logo" src="source/imgs/panda.png" alt="Panda Express Logo">
                     <h2 id="option-heading">Your fortune is...</h2>
                 </div>
-                <div class="center"><img id="current-item" src="source/imgs/opened fortune cookie.png"></div>
+                <div class="center"><img class ="cookie-display" src="source/imgs/opened fortune cookie.png"></div>
                 <h2 id="fortune-text"></h2>
                 <div id="plate-button-container">
                     <button id="play-again">Play Again</button>

--- a/source/css/styles.css
+++ b/source/css/styles.css
@@ -1,8 +1,9 @@
 #front-page,
 #meal-size,
-#option-1,
-#option-2,
-#option-3,
+#side,
+#entree-1,
+#entree-2,
+#entree-3,
 #fortune-cookie-reveal,
 #fortune {
     display: none;
@@ -145,7 +146,14 @@ button:hover {
   align-items: center;
 }
 
-#current-item {
+.current-item {
+  padding: 10px;
+  width: 300px;
+  height: 300px;
+  margin-bottom: 20px;
+}
+
+.cookie-display {
   padding: 10px;
   width: 300px;
   height: 300px;

--- a/source/js/state.js
+++ b/source/js/state.js
@@ -3,7 +3,8 @@ import gameObject from "./fortunes.js";
 let game;
 let level;
 
-const pages = ['front-page', 'meal-size', 'option-1', 'option-2', 'option-3', 'fortune-cookie-reveal', 'fortune'];
+const pages = ['front-page', 'meal-size', 'side', 'entree-1', 'entree-2', 'entree-3', 'fortune-cookie-reveal', 'fortune'];
+const MealSrcs = ['source/imgs/bowl.png', 'source/imgs/plate.png', 'source/imgs/large plate.png'];
 
 function hideAllPages() {
     pages.forEach(page => document.getElementById(page).style.display = 'none');
@@ -30,13 +31,19 @@ window.addEventListener('DOMContentLoaded', (event) => {
 
     ['bowl', 'plate', 'large-plate'].forEach((id, index) => {
         addClickEvent(id, () => {
-            level = index + 1;
+            //bowl = 0 + 2 (side + entree), plate = 1 + 2 (side + 2 entrees), large = 2 + 2 (side + 3 entrees)
+            level = index + 2;
             hideAllPages();
-            document.getElementById('option-1').style.display = 'block';
+            document.getElementById('side').style.display = 'block';
+            let mealImages = document.getElementsByClassName('current-item');
+            console.log(mealImages);
+            for (let i = 0; i < mealImages.length; i++) {
+                mealImages[i].src = MealSrcs[index];
+            }
         });
     });
 
-    for (let i = 1; i <= 3; i++) {
+    for (let i = 1; i <= 4; i++) {
         for (let j = 1; j <= 4; j++) {
             addClickEvent(`option-${i}-${j}`, () => {
                 switch (j) {
@@ -54,7 +61,7 @@ window.addEventListener('DOMContentLoaded', (event) => {
                 if (i === level) {
                     document.getElementById('fortune-cookie-reveal').style.display = 'block';
                 } else {
-                    document.getElementById(`option-${i + 1}`).style.display = 'block';
+                    document.getElementById(`entree-${i}`).style.display = 'block';
                 }
             });
         }


### PR DESCRIPTION
I did not stylistically change anything, just fixed a few things:
1. added a 'side' page, and renamed the other 'option' pages to 'entree' pages.
- the site under this branch now asks for a selection of a side (fried rice, chow mein, white rice), just as what would happen at Panda, before asking for your entree choices - there are still the correct number of entree (the same as before).
2. I resolved the following error: the meal type (bowl, plate, large plate) image changing during option selection.
3. To do number 2, I had to change the 'id="current-item"' to 'class="current-item"' for all of the mealtype images, as well as create a new class for the fortune cookies image called 'cookie-display'.
4. I renamed the titles of the pages from 'choose option-1' to 'choose your side', 'choose your first entree', 'choose your second entree', etc.

Please review the functionality of the website/neatness of the code.